### PR TITLE
Replace deprecated Gradle-version with latest recommended version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,6 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.2.2'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@
 buildscript {
     repositories {
         mavenCentral()
+        maven {
+            url 'https://dl.bintray.com/drummer-aidan/maven'
+        }
     }
 
     dependencies {

--- a/wail-app/build.gradle
+++ b/wail-app/build.gradle
@@ -61,7 +61,7 @@ dependencies {
     compile 'com.android.support:cardview-v7:21.0.3'
     compile 'com.melnykov:floatingactionbutton:1.1.0'
     compile 'com.rengwuxian.materialedittext:library:1.7.1'
-    compile 'com.afollestad:material-dialogs:0.6.2.1'
+    compile 'com.afollestad:material-dialogs:0.7.3.1'
     compile 'com.jakewharton:butterknife:5.1.2'
 
     compile fileTree(dir: 'libs', include: '*.jar')


### PR DESCRIPTION
This fixes a error, which occurs on imports into latest Android Studio (1.2).