### PR TITLE
Fix lint warnings #147

### DIFF
--- a/wail-app/src/androidTest/java/com/artemzin/android/wail/test/unit/util/IntentUtilTest.java
+++ b/wail-app/src/androidTest/java/com/artemzin/android/wail/test/unit/util/IntentUtilTest.java
@@ -15,7 +15,7 @@ public class IntentUtilTest extends BaseAndroidTestCase {
     }
 
     public void testGetLongOrIntExtraNullExtraName() {
-        assertEquals(-1, IntentUtil.getLongOrIntExtra(new Intent(), -1, null));
+        assertEquals(-1, IntentUtil.getLongOrIntExtra(new Intent(), -1, (String[]) null));
     }
 
     public void testGetLongOrIntNoExtra() {

--- a/wail-app/src/main/AndroidManifest.xml
+++ b/wail-app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:name=".WAILApp"
         android:allowBackup="true"
         android:icon="@drawable/wail_launcher_icon"
-        android:label="@string/app_name">
+        android:label="@string/app_name"
+        android:supportsRtl="true">
 
         <activity
             android:name=".ui.activity.MainActivity"

--- a/wail-app/src/main/AndroidManifest.xml
+++ b/wail-app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.artemzin.android.wail">
 
     <uses-permission android:name="android.permission.INTERNET" />
@@ -62,7 +63,8 @@
         <receiver
             android:name="com.google.analytics.tracking.android.CampaignTrackingReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.android.vending.INSTALL_REFERRER" />
             </intent-filter>
@@ -96,7 +98,8 @@
         <receiver
             android:name=".receiver.music.WAILReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.artemzin.android.wail.api.metachanged" />
             </intent-filter>
@@ -105,7 +108,8 @@
         <receiver
             android:name=".receiver.music.AndroidMusicReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.android.music.metachanged" />
                 <action android:name="com.android.music.playstatechanged" />
@@ -116,7 +120,8 @@
         <receiver
             android:name=".receiver.music.SonyEricssonMusicAppReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.sonyericsson.music.playbackcontrol.ACTION_TRACK_STARTED" />
                 <action android:name="com.sonyericsson.music.playbackcontrol.ACTION_PAUSED" />
@@ -127,7 +132,8 @@
         <receiver
             android:name=".receiver.music.HtcMusicAppReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.htc.music.metachanged" />
                 <action android:name="com.htc.music.playbackcomplete" />
@@ -138,7 +144,8 @@
         <receiver
             android:name=".receiver.music.RocketMusicPlayerReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.jrtstudio.music.metachanged" />
                 <action android:name="com.jrtstudio.music.playstatechanged" />
@@ -149,7 +156,8 @@
         <receiver
             android:name=".receiver.music.MIUIPlayerReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.miui.player.metachanged" />
                 <action android:name="com.miui.player.playstatechanged" />
@@ -160,7 +168,8 @@
         <receiver
             android:name=".receiver.music.RdioPlayerReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.rdio.android.playstatechanged" />
                 <action android:name="com.rdio.android.metachanged" />
@@ -171,7 +180,8 @@
         <receiver
             android:name=".receiver.music.samsung.SamsungSecAndroidMusicPlayerReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.samsung.sec.android.MusicPlayer.metachanged" />
                 <action android:name="com.samsung.sec.android.MusicPlayer.playbackcomplete" />
@@ -182,7 +192,8 @@
         <receiver
             android:name=".receiver.music.samsung.SamsungMusicReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.samsung.music.metachanged" />
                 <action android:name="com.samsung.music.playbackcomplete" />
@@ -193,7 +204,8 @@
         <receiver
             android:name=".receiver.music.samsung.SamsungSecReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.samsung.sec.metachanged" />
                 <action android:name="com.samsung.sec.playbackcomplete" />
@@ -204,7 +216,8 @@
         <receiver
             android:name=".receiver.music.samsung.SamsungSecAndroidReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.samsung.sec.android.metachanged" />
                 <action android:name="com.samsung.sec.android.playbackcomplete" />
@@ -215,7 +228,8 @@
         <receiver
             android:name=".receiver.music.samsung.SamsungMusicPlayerReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.samsung.MusicPlayer.metachanged" />
                 <action android:name="com.samsung.MusicPlayer.playbackcomplete" />
@@ -228,7 +242,8 @@
         <receiver
             android:name=".receiver.music.WinampReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.nullsoft.winamp.metachanged" />
                 <action android:name="com.nullsoft.winamp.playbackcomplete" />
@@ -239,7 +254,8 @@
         <receiver
             android:name=".receiver.music.AmazonMP3Receiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.amazon.mp3.metachanged" />
                 <action android:name="com.amazon.mp3.playbackcomplete" />
@@ -250,7 +266,8 @@
         <receiver
             android:name=".receiver.music.RhapsodyReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.rhapsody.metachanged" />
                 <action android:name="com.rhapsody.playbackcomplete" />
@@ -261,7 +278,8 @@
         <receiver
             android:name=".receiver.music.AppoloReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.andrew.appolo.metachanged" />
                 <action android:name="com.andrew.appolo.playbackcomplete" />
@@ -272,7 +290,8 @@
         <receiver
             android:name=".receiver.music.JetAudioReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.jetappfactory.jetaudio.metachanged" />
                 <action android:name="com.jetappfactory.jetaudio.playbackcomplete" />
@@ -283,7 +302,8 @@
         <receiver
             android:name=".receiver.music.PlayerProTrialReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.tbig.playerprotrial.metachanged" />
                 <action android:name="com.tbig.playerprotrial.playbackcomplete" />
@@ -294,7 +314,8 @@
         <receiver
             android:name=".receiver.music.PlayerProReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.tbig.playerpro.metachanged" />
                 <action android:name="com.tbig.playerpro.playbackcomplete" />
@@ -305,7 +326,8 @@
         <receiver
             android:name=".receiver.music.LGMusicAppReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.lge.music.metachanged" />
                 <action android:name="com.lge.music.playstatechanged" />
@@ -316,7 +338,8 @@
         <receiver
             android:name=".receiver.music.SpotifyReceiver"
             android:exported="true"
-            android:enabled="true">
+            android:enabled="true"
+            tools:ignore="ExportedReceiver">
             <intent-filter>
                 <action android:name="com.spotify.mobile.android.metadatachanged" />
                 <action android:name="com.spotify.mobile.android.playbackstatechanged" />

--- a/wail-app/src/main/AndroidManifest.xml
+++ b/wail-app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:allowBackup="true"
         android:icon="@drawable/wail_launcher_icon"
         android:label="@string/app_name"
-        android:supportsRtl="true">
+        android:supportsRtl="false">
 
         <activity
             android:name=".ui.activity.MainActivity"

--- a/wail-app/src/main/java/com/artemzin/android/wail/storage/db/IgnoredPlayersDBHelper.java
+++ b/wail-app/src/main/java/com/artemzin/android/wail/storage/db/IgnoredPlayersDBHelper.java
@@ -70,6 +70,8 @@ public class IgnoredPlayersDBHelper {
             }
         }
 
+        cursor.close();
+
         return result;
     }
 

--- a/wail-app/src/main/java/com/artemzin/android/wail/ui/activity/MainActivity.java
+++ b/wail-app/src/main/java/com/artemzin/android/wail/ui/activity/MainActivity.java
@@ -142,7 +142,7 @@ public class MainActivity extends BaseActivity {
 
                 if (rowView == null) {
                     LayoutInflater inflater = getLayoutInflater();
-                    rowView = inflater.inflate(R.layout.activity_main_drawer_item_layout, null, true);
+                    rowView = inflater.inflate(R.layout.activity_main_drawer_item_layout, parent, false);
                     holder = new ViewHolder();
                     holder.background = rowView;
                     holder.textView = (TypefaceTextView) rowView.findViewById(R.id.activity_main_drawer_item_text);

--- a/wail-app/src/main/java/com/artemzin/android/wail/ui/fragment/LastfmLoginFragment.java
+++ b/wail-app/src/main/java/com/artemzin/android/wail/ui/fragment/LastfmLoginFragment.java
@@ -58,7 +58,7 @@ public class LastfmLoginFragment extends BaseFragment {
         final String userName = loginEditText.getText().toString();
         final String password = passwordEditText.getText().toString();
 
-        View view = getActivity().getLayoutInflater().inflate(R.layout.fragment_progress_dialog, null);
+        View view = View.inflate(getActivity(), R.layout.fragment_progress_dialog, null);
         ((TextView) view.findViewById(R.id.progress_dialog_message)).setText(getString(R.string.lastfm_logging_progress_dialog_message));
         final AlertDialog progressDialog = new AlertDialog.Builder(getActivity())
                 .setView(view)

--- a/wail-app/src/main/java/com/artemzin/android/wail/ui/fragment/main/SettingsFragment.java
+++ b/wail-app/src/main/java/com/artemzin/android/wail/ui/fragment/main/SettingsFragment.java
@@ -195,7 +195,7 @@ public class SettingsFragment extends BaseFragment implements DialogDecorator.Ca
                 WAILSettings.setEnabled(getActivity(), isChecked);
 
                 final Toast toast = Toast.makeText(getActivity(), "", Toast.LENGTH_SHORT);
-                toast.setGravity(Gravity.TOP | Gravity.RIGHT, 0, (int) DisplayUnitsConverter.dpToPx(getActivity(), 60));
+                toast.setGravity(Gravity.TOP | Gravity.END, 0, (int) DisplayUnitsConverter.dpToPx(getActivity(), 60));
 
                 if (isChecked) {
                     setUIStateWailEnabled();

--- a/wail-app/src/main/java/com/artemzin/android/wail/ui/fragment/settings/SettingsIgnoredPlayersFragment.java
+++ b/wail-app/src/main/java/com/artemzin/android/wail/ui/fragment/settings/SettingsIgnoredPlayersFragment.java
@@ -73,7 +73,7 @@ public class SettingsIgnoredPlayersFragment extends Fragment implements AdapterV
 
                     if (rowView == null) {
                         LayoutInflater inflater = getActivity().getLayoutInflater();
-                        rowView = inflater.inflate(R.layout.settings_ignored_players_item_layout, null, true);
+                        rowView = inflater.inflate(R.layout.settings_ignored_players_item_layout, parent, false);
                         holder = new ViewHolder();
                         holder.textView = (TextView) rowView
                                 .findViewById(R.id.settings_ignored_players_list_view_text);
@@ -103,9 +103,8 @@ public class SettingsIgnoredPlayersFragment extends Fragment implements AdapterV
         final ApplicationInfo applicationInfo = (ApplicationInfo) adapterView.getAdapter().getItem(i);
 
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-        LayoutInflater inflater = getActivity().getLayoutInflater();
 
-        View titleView = inflater.inflate(R.layout.dialog_fragment_title, null);
+        View titleView = View.inflate(getActivity(), R.layout.dialog_fragment_title, null);
         ((TextView) titleView.findViewById(R.id.dialog_fragment_title_text_view))
                 .setText(String.format(getString(R.string.settings_confirm_unignoring_player),
                         packageManager.getApplicationLabel(applicationInfo)));

--- a/wail-app/src/main/java/com/artemzin/android/wail/util/LocaleUtil.java
+++ b/wail-app/src/main/java/com/artemzin/android/wail/util/LocaleUtil.java
@@ -12,7 +12,7 @@ import java.util.Locale;
 public class LocaleUtil {
 
     private static String lang(String originalLangName) {
-        return originalLangName == null ? null : originalLangName.substring(0, 2).toLowerCase();
+        return originalLangName == null ? null : originalLangName.substring(0, 2).toLowerCase(Locale.US);
     }
 
     public static void updateLanguage(Context context, String newLanguage) {

--- a/wail-app/src/main/res/layout/activity_main_drawer_item_layout.xml
+++ b/wail-app/src/main/res/layout/activity_main_drawer_item_layout.xml
@@ -7,7 +7,9 @@
         android:layout_width="24dp"
         android:layout_gravity="center"
         android:layout_marginLeft="@dimen/main_drawer_padding"
-        android:id="@+id/activity_main_drawer_item_image"/>
+        android:layout_marginStart="@dimen/main_drawer_padding"
+        android:id="@+id/activity_main_drawer_item_image"
+        android:contentDescription="@string/drawer_item_image_content_description"/>
 
     <com.artemzin.android.wail.ui.TypefaceTextView
         android:id="@+id/activity_main_drawer_item_text"

--- a/wail-app/src/main/res/layout/fragment_progress_dialog.xml
+++ b/wail-app/src/main/res/layout/fragment_progress_dialog.xml
@@ -10,7 +10,8 @@
     <ProgressBar
         android:layout_height="45dp"
         android:layout_width="45dp"
-        android:layout_marginLeft="25dp"/>
+        android:layout_marginLeft="25dp"
+        android:layout_marginStart="25dp"/>
 
     <com.artemzin.android.wail.ui.TypefaceTextView
         android:id="@+id/progress_dialog_message"
@@ -18,6 +19,7 @@
         android:layout_width="wrap_content"
         android:layout_gravity="center_vertical"
         android:layout_marginLeft="30dp"
+        android:layout_marginStart="30dp"
         android:paddingRight="55dp"
         android:textSize="14sp"
         android:textColor="@color/light_theme_background"/>

--- a/wail-app/src/main/res/layout/fragment_progress_dialog.xml
+++ b/wail-app/src/main/res/layout/fragment_progress_dialog.xml
@@ -20,7 +20,8 @@
         android:layout_gravity="center_vertical"
         android:layout_marginLeft="30dp"
         android:layout_marginStart="30dp"
-        android:paddingRight="55dp"
+        android:layout_marginRight="55dp"
+        android:layout_marginEnd="55dp"
         android:textSize="14sp"
         android:textColor="@color/light_theme_background"/>
 

--- a/wail-app/src/main/res/layout/navigation_drawer_layout.xml
+++ b/wail-app/src/main/res/layout/navigation_drawer_layout.xml
@@ -19,26 +19,19 @@
             android:layout_width="match_parent"
             android:layout_height="156dp"
             android:layout_marginBottom="6dp"
+            android:orientation="vertical"
+            android:paddingBottom="12dp"
             android:clickable="true"
             android:gravity="bottom"
             android:background="@drawable/drawer_header_background">
 
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/main_drawer_standard_increment"
-                android:orientation="vertical"
-                android:gravity="start|center_vertical"
-                android:clickable="true">
+            <com.artemzin.android.wail.ui.TypefaceTextView
+                android:id="@+id/main_left_drawer_title_main"
+                style="@style/AppTheme.DrawerTitleMainText" />
 
-                <com.artemzin.android.wail.ui.TypefaceTextView
-                    android:id="@+id/main_left_drawer_title_main"
-                    style="@style/AppTheme.DrawerTitleMainText" />
-
-                <com.artemzin.android.wail.ui.TypefaceTextView
-                    android:id="@+id/main_left_drawer_title_secondary"
-                    style="@style/AppTheme.DrawerTitleSecondaryText" />
-
-            </LinearLayout>
+            <com.artemzin.android.wail.ui.TypefaceTextView
+                android:id="@+id/main_left_drawer_title_secondary"
+                style="@style/AppTheme.DrawerTitleSecondaryText" />
 
         </LinearLayout>
 

--- a/wail-app/src/main/res/layout/track_list_item.xml
+++ b/wail-app/src/main/res/layout/track_list_item.xml
@@ -2,7 +2,8 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    style="?trackListItemBackground">
+    style="?trackListItemBackground"
+    android:baselineAligned="false">
 
     <LinearLayout
         android:orientation="vertical"
@@ -40,7 +41,7 @@
             android:layout_marginTop="3dp"
             android:textSize="12sp"
             tools:textColor="@color/light_theme_text_secondary"
-            android:gravity="right"
+            android:gravity="end"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
@@ -50,7 +51,7 @@
             android:textSize="12sp"
             android:layout_marginTop="0dp"
             android:textColor="@color/light_theme_text_secondary"
-            android:gravity="bottom|right"
+            android:gravity="bottom|end"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1" />

--- a/wail-app/src/main/res/layout/track_list_item.xml
+++ b/wail-app/src/main/res/layout/track_list_item.xml
@@ -10,7 +10,8 @@
         android:layout_height="wrap_content"
         android:layout_width="0dp"
         android:layout_weight="65"
-        android:paddingRight="15dp">
+        android:layout_marginRight="15dp"
+        android:layout_marginEnd="15dp">
 
         <com.artemzin.android.wail.ui.TypefaceTextView
             android:id="@+id/track_list_item_track"

--- a/wail-app/src/main/res/values-de/strings.xml
+++ b/wail-app/src/main/res/values-de/strings.xml
@@ -32,7 +32,6 @@
     <string name="main_now_scrobbling_label">Scrobbelt zurzeit: %1$s</string>
     <string name="main_now_scrobbling_nothing">nichts</string>
     <string name="main_pull_down_to_refresh_toast">Ziehen, um Daten zu aktualisieren</string>
-    <string name="main_pull_to_refresh_pull_text">Ziehen, um zu aktualisieren</string>
     <string name="main_refreshing">Wird aktualisiert …</string>
     <string name="main_updated_today_at">Stand heute um %1$s</string>
     <string name="main_updated_yesterday_at">Stand gestern um %1$s</string>
@@ -46,8 +45,6 @@
     <string name="main_feedback_please">Ohne ein Feedback auf Google Play ist WAIL traurig.</string>
     <string name="main_feedback_please_happy_toast">Jetzt ist WAIL glücklich.</string>
     <string name="main_track_loved">Zu Lieblingsliedern hinzugefügt.</string>
-    <string name="main_love_track_button_content_description">Lieblingslied-Taste</string>
-    <string name="main_love_track_button_label">Füge aktuellen Titel den Lieblingsliedern hinzu</string>
     <!-- END of main screen strings -->
 
     <!-- START of tracks list screen strings -->
@@ -60,10 +57,8 @@
     <string name="track_status_scrobble_success">Gescrobbelt</string>
     <string name="track_status_unknown">Unbekannter Status</string>
     <string name="tracks_search_ab_title">Suchen</string>
-    <string name="tracks_search_hint">Suche in gescrobbelten Titeln</string>
     <string name="tracks_search_error_toast">Kann Suche nicht ausführen</string>
     <string name="tracks_search_no_results">Zu "%1$s" nichts gefunden.</string>
-    <string name="tracks_search_clear_text">Suche leeren</string>
     <!-- END of tracks list screen strings -->
 
     <!-- START of settings screen strings -->
@@ -93,7 +88,6 @@
     <string name="settings_sound_notifications_title">Tonmitteilungen</string>
     <string name="settings_sound_notifications_description">Ton wenn Titel gescrobbelt werden oder wenn dies nicht möglich gewesen ist.</string>
     <string name="settings_status_bar_notifications_title">Statusbar-Mitteilungen</string>
-    <string name="settings_theme">Design</string>
     <string name="settings_theme_switch_label">Dunkles Design benutzen</string>
     <string name="settings_other">Weitere Einstellungen</string>
     <string name="settings_email_to_developers">E-Mail an Entwickler senden</string>
@@ -105,7 +99,6 @@
 
     <!-- START of sound notifications screen strings -->
     <string name="settings_sound_notifications_activity_label">Tonmitteilungen</string>
-    <string name="settings_sound_notifications_main_title">Liste von Mitteilungen</string>
     <string name="settings_sound_notifications_pro_tip">Tipp: Beschreibung berühren um Ton anzuhören</string>
     <string name="settings_notifications_track_scrobbled">WAIL scrobbelt Titel</string>
     <string name="settings_track_was_skipped">WAIL hat Titel wegen Länge übersprungen</string>
@@ -115,7 +108,6 @@
     <!-- END of sound notifications screen strings -->
 
     <string name="settings_status_bar_notifications_activity_label">Statusbar-Mitteilungen</string>
-    <string name="settings_status_bar_notifications_main_title">Liste von Mitteilungen</string>
     <string name="settings_notifications_track_now_scrobbling">WAIL scrobbelt Titel</string>
     <string name="settings_notifications_min_priority">Minimum notification priority</string>
 

--- a/wail-app/src/main/res/values-de/strings.xml
+++ b/wail-app/src/main/res/values-de/strings.xml
@@ -119,6 +119,7 @@
     <string name="dialog_cancel">Abbrechen</string>
     <string name="dialog_save">Speichern</string>
     <string name="drawer_registered_at">"Mitglied seit "</string>
+    <string name="drawer_item_image_content_description">Drawer item image</string>
 
     <string-array name="drawer_items">
         <item>Start</item>

--- a/wail-app/src/main/res/values-ko/strings.xml
+++ b/wail-app/src/main/res/values-ko/strings.xml
@@ -119,6 +119,7 @@
     <string name="dialog_cancel">취소</string>
     <string name="dialog_save">저장</string>
     <string name="drawer_registered_at">"등록 날짜: "</string>
+    <string name="drawer_item_image_content_description">서랍장 항목 이미지</string>
 
     <string-array name="drawer_items">
         <item>메인</item>

--- a/wail-app/src/main/res/values-ko/strings.xml
+++ b/wail-app/src/main/res/values-ko/strings.xml
@@ -32,7 +32,6 @@
     <string name="main_now_scrobbling_label">현재 집계 중인 곡: %1$s</string>
     <string name="main_now_scrobbling_nothing">없네요 :(</string>
     <string name="main_pull_down_to_refresh_toast">새로고침하려면 아래로 당겨주세요 :)</string>
-    <string name="main_pull_to_refresh_pull_text">당겨서 새로고침</string>
     <string name="main_refreshing">새로고침 중…</string>
     <string name="main_updated_today_at">오늘 %1$s에 업데이트됨</string>
     <string name="main_updated_yesterday_at">어제 %1$s에 업데이트됨</string>
@@ -46,8 +45,6 @@
     <string name="main_feedback_please">Google Play에 WAIL 피드백을 남겨주지 않으셔서 슬프네요 :(</string>
     <string name="main_feedback_please_happy_toast">이제 WAIL은 행복합니다 ;)</string>
     <string name="main_track_loved">해당 트랙이 선호 목록에 추가되었습니다 :)</string>
-    <string name="main_love_track_button_content_description">선호 목록에 추가 버튼</string>
-    <string name="main_love_track_button_label">현재 재생 중인 트랙을 선호 목록에 추가</string>
     <!-- END of main screen strings -->
 
     <!-- START of tracks list screen strings -->
@@ -60,10 +57,8 @@
     <string name="track_status_scrobble_success">집계됨</string>
     <string name="track_status_unknown">알 수 없는 상태입니다 :(</string>
     <string name="tracks_search_ab_title">검색</string>
-    <string name="tracks_search_hint">집계된 트랙 검색</string>
     <string name="tracks_search_error_toast">검색을 진행할 수 없습니다 :(</string>
     <string name="tracks_search_no_results">해당 검색어에 대한 검색 결과 없음: %1$s :(</string>
-    <string name="tracks_search_clear_text">검색어 삭제</string>
     <!-- END of tracks list screen strings -->
 
     <!-- START of settings screen strings -->
@@ -93,7 +88,6 @@
     <string name="settings_sound_notifications_title">사운드 알림</string>
     <string name="settings_sound_notifications_description">Track scrobbled sound, etc…</string>
     <string name="settings_status_bar_notifications_title">상태바 알림</string>
-    <string name="settings_theme">테마</string>
     <string name="settings_theme_switch_label">다크 테마</string>
     <string name="settings_other">기타</string>
     <string name="settings_email_to_developers">개발자에게 이메일 전송</string>
@@ -105,7 +99,6 @@
 
     <!-- START of sound notifications screen strings -->
     <string name="settings_sound_notifications_activity_label">사운드 알림</string>
-    <string name="settings_sound_notifications_main_title">알림 사운드 목록</string>
     <string name="settings_sound_notifications_pro_tip">프로팁: 사운드 요약을 탭하여 재생하세요</string>
     <string name="settings_notifications_track_scrobbled">WAIL이 집계된 트랙을 표시합니다</string>
     <string name="settings_track_was_skipped">WAIL이 재생곡이 최소 시간동안 재생되지 않아 스킵합니다</string>
@@ -115,7 +108,6 @@
     <!-- END of sound notifications screen strings -->
 
     <string name="settings_status_bar_notifications_activity_label">상태바 알림</string>
-    <string name="settings_status_bar_notifications_main_title">상태바 알림 목록</string>
     <string name="settings_notifications_track_now_scrobbling">WAIL이 이제 음악 트랙을 집계합니다</string>
     <string name="settings_notifications_min_priority">Minimum notification priority</string>
 

--- a/wail-app/src/main/res/values-ru/strings.xml
+++ b/wail-app/src/main/res/values-ru/strings.xml
@@ -18,12 +18,9 @@
     <string name="lastfm_password_hint">Пароль</string>
     <string name="main_feedback_please">WAIL в печали без Вашего отзыва в Google Play :(</string>
     <string name="main_feedback_please_happy_toast">Теперь WAIL счастлив :)</string>
-    <string name="main_love_track_button_content_description">Кнопка "Добавить трек в любимые"</string>
-    <string name="main_love_track_button_label">Добавить трек в любимые</string>
     <string name="main_now_scrobbling_label">Скробблится: %1$s </string>
     <string name="main_now_scrobbling_nothing">ничего :(</string>
     <string name="main_pull_down_to_refresh_toast">Потяните вниз, чтобы обновить данные :)</string>
-    <string name="main_pull_to_refresh_pull_text">Потяните вниз</string>
     <string name="main_refreshing">Обновление…</string>
     <string name="main_refresh_info_from_lastfm_api_error">Ошибка last.fm: %1$s</string>
     <string name="main_refresh_info_from_lastfm_network_error">Ошибка сетевого соединения, попробуйте позже</string>
@@ -64,14 +61,11 @@
     <string name="settings_scrobbling_over_mobile_network_enabled_toast">Скробблинг через мобильное интернет-подключение включен!</string>
     <string name="settings_sound_notifications_activity_label">Звуковые уведомления</string>
     <string name="settings_sound_notifications_description">Можно прослушать звук уведомленй и т.д.</string>
-    <string name="settings_sound_notifications_main_title">Список звуковых уведомлений</string>
     <string name="settings_sound_notifications_pro_tip">Подсказка: коснитесь чтобы проиграть звук</string>
     <string name="settings_sound_notifications_title">Звуковые уведомления</string>
     <string name="settings_sound_notifications_toast_can_not_play_sound">Невозможно воспроизвести звук :(</string>
     <string name="settings_status_bar_notifications_activity_label">Уведомления в статус баре</string>
     <string name="settings_status_bar_notifications_title">Уведомления в статус баре</string>
-    <string name="settings_status_bar_notifications_main_title">Спискок уведомлений в статус баре</string>
-    <string name="settings_theme">Тема</string>
     <string name="settings_theme_switch_label">Темная тема</string>
     <string name="settings_track_was_skipped">WAIL пропустил трек потому что трек не был прослушан достаточно долго</string>
     <string name="settings_wail_disabled_toast">WAIL отключен</string>
@@ -88,8 +82,6 @@
     <string name="tracks_list_empty_motivation_text">Попробуйте послушать музыку в своем любимом плеере и прослушанные треки появятся здесь!</string>
     <string name="tracks_search_no_results">Нет результатов для: %1$s :(</string>
     <string name="tracks_search_error_toast">Невозможно произвести поиск :(</string>
-    <string name="tracks_search_hint">Искать в заскроббленных треках</string>
-    <string name="tracks_search_clear_text">Очистить текст</string>
     <string name="settings_ignored_players_activity_label">Игнорируемые медиа плееры</string>
     <string name="settings_ignored_players_item_title">Игнорируемые медиа плееры</string>
     <string name="settings_ignored_players_item_desc">Треки, воспроизводимые этими плеерами не будут скробблиться</string>

--- a/wail-app/src/main/res/values-ru/strings.xml
+++ b/wail-app/src/main/res/values-ru/strings.xml
@@ -92,6 +92,7 @@
     <string name="settings_ignored_players_empty_text">У Вас нет игнорируемых плееров</string>
     <string name="main_ignore_this_player_button_text">Игнорировать этот плеер</string>
     <string name="drawer_registered_at">"Зарегистрирован(а) "</string>
+    <string name="drawer_item_image_content_description">Drawer item image</string>
     <string name="settings_logout">Выйти</string>
     <string name="setting_logout_warning">Все данные о скробблинге будут удалены! Вы уверены?</string>
     <string name="settings_notifications_min_priority">Минимальный приоритет уведомлений</string>

--- a/wail-app/src/main/res/values/colors.xml
+++ b/wail-app/src/main/res/values/colors.xml
@@ -29,7 +29,6 @@
     <color name="drawer_item_selected_background">#14000000</color>
 
     <color name="drawer_item_text">#dd000000</color>
-    <color name="drawer_header_background">#fff2f2f2</color>
 
     <!--Light theme-->
 
@@ -56,7 +55,6 @@
     <color name="dark_theme_text_secondary">#bebebe</color>
 
     <color name="dark_theme_track_today_background">#ff5d5d5d</color>
-    <color name="dark_theme_tracks_today_ripple">#C3C3C3</color>
 
     <color name="dark_theme_settings_background">#ff646769</color>
 

--- a/wail-app/src/main/res/values/dimens.xml
+++ b/wail-app/src/main/res/values/dimens.xml
@@ -1,8 +1,6 @@
 <resources>
     <!-- Default screen margins, per the Android Design guidelines. -->
-    <dimen name="activity_horizontal_margin_left">20dp</dimen>
     <dimen name="activity_horizontal_margin">25dp</dimen>
-    <dimen name="activity_vertical_margin">25dp</dimen>
 
     <dimen name="settings_item_title">18sp</dimen>
     <dimen name="settings_item_desc">14sp</dimen>

--- a/wail-app/src/main/res/values/strings.xml
+++ b/wail-app/src/main/res/values/strings.xml
@@ -32,7 +32,6 @@
     <string name="main_now_scrobbling_label">Now scrobbling: %1$s</string>
     <string name="main_now_scrobbling_nothing">nothing :(</string>
     <string name="main_pull_down_to_refresh_toast">Pull down to refresh data :)</string>
-    <string name="main_pull_to_refresh_pull_text">Pull to refresh</string>
     <string name="main_refreshing">Refreshing…</string>
     <string name="main_updated_today_at">updated today at %1$s</string>
     <string name="main_updated_yesterday_at">updated yesterday at %1$s</string>
@@ -46,8 +45,6 @@
     <string name="main_feedback_please">WAIL is sad without your feedback on the Google Play :(</string>
     <string name="main_feedback_please_happy_toast">Now WAIL is happy ;)</string>
     <string name="main_track_loved">Track loved :)</string>
-    <string name="main_love_track_button_content_description">Love track button</string>
-    <string name="main_love_track_button_label">Love current track</string>
     <!-- END of main screen strings -->
 
     <!-- START of tracks list screen strings -->
@@ -60,10 +57,8 @@
     <string name="track_status_scrobble_success">Scrobbled</string>
     <string name="track_status_unknown">Unknown state :(</string>
     <string name="tracks_search_ab_title">Search</string>
-    <string name="tracks_search_hint">Search scrobbled tracks</string>
     <string name="tracks_search_error_toast">Can not proceed search :(</string>
     <string name="tracks_search_no_results">No search results for text: %1$s :(</string>
-    <string name="tracks_search_clear_text">Clear search text</string>
     <!-- END of tracks list screen strings -->
 
     <!-- START of settings screen strings -->
@@ -84,7 +79,6 @@
     <string name="settings_ignored_players_image_content_description">Ignored player image</string>
     <string name="settings_confirm_unignoring_player">Do you want to stop ignoring player \"%s\"?</string>
     <string name="settings_ignored_players_empty_text">You have no ignored players</string>
-    <string name="settings_update_nowplaying_title" translatable="false">#nowplaying</string>
     <string name="settings_lastfm_update_nowplaying_title">Listening now on last.fm</string>
     <string name="settings_lastfm_update_nowplaying_enabled_toast">Last.fm update nowplaying enabled</string>
     <string name="settings_lastfm_update_nowplaying_disabled_toast">Last.fm update nowplaying turned off</string>
@@ -94,7 +88,6 @@
     <string name="settings_sound_notifications_title">Sound notifications</string>
     <string name="settings_sound_notifications_description">Track scrobbled sound, etc…</string>
     <string name="settings_status_bar_notifications_title">Status bar notifications</string>
-    <string name="settings_theme">Theme</string>
     <string name="settings_theme_switch_label">Dark theme</string>
     <string name="settings_other">Other</string>
     <string name="settings_email_to_developers">Email developers</string>
@@ -106,7 +99,6 @@
 
     <!-- START of sound notifications screen strings -->
     <string name="settings_sound_notifications_activity_label">Sound notifications</string>
-    <string name="settings_sound_notifications_main_title">List of notifications sounds</string>
     <string name="settings_sound_notifications_pro_tip">Pro tip: tap on the sound description to play it</string>
     <string name="settings_notifications_track_scrobbled">WAIL marked track as scrobbled</string>
     <string name="settings_track_was_skipped">WAIL skipped track because it was not played required time</string>
@@ -116,7 +108,6 @@
     <!-- END of sound notifications screen strings -->
 
     <string name="settings_status_bar_notifications_activity_label">Status bar notifications</string>
-    <string name="settings_status_bar_notifications_main_title">List of status bar notifications</string>
     <string name="settings_notifications_track_now_scrobbling">WAIL is now scrobbling track</string>
     <string name="settings_notifications_min_priority">Minimum notification priority</string>
 

--- a/wail-app/src/main/res/values/strings.xml
+++ b/wail-app/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
     <string name="dialog_cancel">Cancel</string>
     <string name="dialog_save">Save</string>
     <string name="drawer_registered_at">"Registered "</string>
+    <string name="drawer_item_image_content_description">Drawer item image</string>
 
     <string-array name="drawer_items">
         <item>Main</item>

--- a/wail-app/src/main/res/values/strings_do_not_translate.xml
+++ b/wail-app/src/main/res/values/strings_do_not_translate.xml
@@ -15,7 +15,6 @@
         <item>Korean</item>
     </string-array>
 
-    <string name="settings_select_language_title" translatable="false">Language</string>
     <string name="settings_select_language" translatable="false">Select language</string>
     <string name="settings_select_language_activity_label" translatable="false">Select language</string>
     <string name="settings_select_language_current_lang" translatable="false">%s (current)</string>


### PR DESCRIPTION
Fixed 56 lint warnings out of 72.
Some warnings are just suppressed since they are unable to fix (e.g. ExportedReceiver lint warning).