### PR TITLE
Refactor MD5Hash

### DIFF
--- a/wail-app/src/androidTest/java/com/artemzin/android/wail/test/unit/api/MD5HashTest.java
+++ b/wail-app/src/androidTest/java/com/artemzin/android/wail/test/unit/api/MD5HashTest.java
@@ -1,0 +1,19 @@
+
+package com.artemzin.android.wail.test.unit.api;
+
+import com.artemzin.android.wail.api.MD5Hash;
+import com.artemzin.android.wail.test.unit.BaseAndroidTestCase;
+
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Tests for {@link MD5Hash}.
+ */
+public class MD5HashTest extends BaseAndroidTestCase {
+    public void testCalculateMD5() throws NoSuchAlgorithmException {
+        assertEquals("acbd18db4cc2f85cedef654fccc4a4d8", MD5Hash.calculateMD5("foo"));
+        assertEquals("37b51d194a7513e45b56f6524f2d51f2", MD5Hash.calculateMD5("bar"));
+        // With 0-padding
+        assertEquals("0cc175b9c0f1b6a831c399e269772661", MD5Hash.calculateMD5("a"));
+    }
+}

--- a/wail-app/src/main/java/com/artemzin/android/wail/api/MD5Hash.java
+++ b/wail-app/src/main/java/com/artemzin/android/wail/api/MD5Hash.java
@@ -1,6 +1,7 @@
 package com.artemzin.android.wail.api;
 
 import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -9,16 +10,6 @@ import java.security.NoSuchAlgorithmException;
  * @author Artem Zinnatullin [artem.zinnatullin@gmail.com]
  */
 public class MD5Hash {
-
-    private static MessageDigest digest;
-
-    static {
-        try {
-            digest = MessageDigest.getInstance("MD5");
-        } catch (NoSuchAlgorithmException e) {
-            // better never happens
-        }
-    }
 
     /**
      * Calculates MD5 hash from input string <br/>
@@ -29,21 +20,12 @@ public class MD5Hash {
      */
     public static String calculateMD5(String input) throws NoSuchAlgorithmException {
         try {
-            final byte[] bytes = digest.digest(input.getBytes("UTF-8"));
-            final StringBuilder b = new StringBuilder(32);
-
-            for (byte aByte : bytes) {
-                final String hex = Integer.toHexString((int) aByte & 0xFF);
-                if (hex.length() == 1)
-                    b.append('0');
-                b.append(hex);
-            }
-
-            return b.toString();
+            final byte[] digest = MessageDigest.getInstance("MD5").digest(input.getBytes("UTF-8"));
+            return String.format("%032x", new BigInteger(1, digest));
+            //return String.format("%016x", 1234);
         } catch (UnsupportedEncodingException e) {
-            // utf-8 always available
+            // Should not happen: UTF-8 always available
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 }

--- a/wail-app/src/main/java/com/artemzin/android/wail/api/MD5Hash.java
+++ b/wail-app/src/main/java/com/artemzin/android/wail/api/MD5Hash.java
@@ -22,7 +22,6 @@ public class MD5Hash {
         try {
             final byte[] digest = MessageDigest.getInstance("MD5").digest(input.getBytes("UTF-8"));
             return String.format("%032x", new BigInteger(1, digest));
-            //return String.format("%016x", 1234);
         } catch (UnsupportedEncodingException e) {
             // Should not happen: UTF-8 always available
             throw new RuntimeException(e);


### PR DESCRIPTION
- Refactor MD5Hash with String.format and BigInt

  Don't build the hexa string manually with a `StringBuilder`, but use `String.format()` instead.
  Remove static field, since `MessageDigest` already implements the Singleton pattern

- Add MD5HashTest

  Test against current behaviour, including 0-padding.