### PR TITLE
Proguard

### DIFF
--- a/wail-app/build.gradle
+++ b/wail-app/build.gradle
@@ -38,6 +38,8 @@ android {
         debug {
             versionNameSuffix ' debug ' + getDateForVersionName()
             signingConfig signingConfigs.wail
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
         }
 
         release {

--- a/wail-app/proguard.cfg
+++ b/wail-app/proguard.cfg
@@ -1,0 +1,9 @@
+# This is open-source, and we want clear stacktraces
+-dontobfuscate
+-optimizationpasses 4
+
+# For Butterknife
+-dontwarn butterknife.internal.**
+-keep class **$$ViewInjector { *; }
+-keepnames class * { @butterknife.InjectView *;}
+-dontwarn butterknife.Views$InjectViewProcessor


### PR DESCRIPTION
Apply proguard on release. This reduces the apk size from 2.7MB to 2.0MB

I have not applied the proguarding on debug because it slows down the build – ideally we could have build flavors.

I have manually tested the app, but this change is riskier than my other changes today – risk of crash with NoClassDefFound