### PR TITLE
Proguard

### DIFF
--- a/wail-app/build.gradle
+++ b/wail-app/build.gradle
@@ -35,15 +35,28 @@ android {
     }
 
     buildTypes {
+        // A build signed with debug keys.
+        // Not using proguard, it's fast to package.
+        fast_debug {
+            versionNameSuffix ' debug ' + getDateForVersionName()
+            signingConfig signingConfigs.wail
+            // Gradle defaults to debuggable=false for variants other than "debug".
+            debuggable true
+        }
+        // A build signed with debug keys.
+        // Using proguard, it's slower to package.
         debug {
             versionNameSuffix ' debug ' + getDateForVersionName()
             signingConfig signingConfigs.wail
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
         }
-
+        // A build signed with release keys.
+        // Using proguard for code optimization and reducing the apk size.
         release {
             signingConfig signingConfigs.wail
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
         }
     }
 

--- a/wail-app/build.gradle
+++ b/wail-app/build.gradle
@@ -38,6 +38,8 @@ android {
         debug {
             versionNameSuffix ' debug ' + getDateForVersionName()
             signingConfig signingConfigs.wail
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard.cfg'
         }
 
         release {

--- a/wail-app/proguard.cfg
+++ b/wail-app/proguard.cfg
@@ -1,0 +1,9 @@
+# This is open-source, and we want clear stacktraces
+-dontobfuscate
+-optimizationpasses 4
+
+# For Butterknife
+-dontwarn butterknife.internal.**
+-keep class **$$ViewInjector { *; }
+-keepnames class * { @butterknife.InjectView *;}
+-dontwarn butterknife.Views$InjectViewProcessor

--- a/wail-app/proguard.cfg
+++ b/wail-app/proguard.cfg
@@ -2,6 +2,9 @@
 -dontobfuscate
 -optimizationpasses 4
 
+# for support lib
+-keep class android.support.v7.widget.SearchView { *; }
+
 # For Butterknife
 -dontwarn butterknife.internal.**
 -keep class **$$ViewInjector { *; }


### PR DESCRIPTION
With proguard, the apk size is reduced from 2.7MB to 2MB.
* Apply proguard to variants “debug” and “release”.
* Introduce a new variant “fast_debug” which doesn’t proguard, and hence is faster to package.
* Add proguard exclusion for Butterknife and support lib

Fix internal cleanup #168