### PR TITLE
Use RingtoneManager for notifications

### DIFF
--- a/wail-app/src/main/java/com/artemzin/android/wail/notifications/SoundNotificationsManager.java
+++ b/wail-app/src/main/java/com/artemzin/android/wail/notifications/SoundNotificationsManager.java
@@ -1,9 +1,13 @@
 package com.artemzin.android.wail.notifications;
 
+import android.app.Notification;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.media.MediaPlayer;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.SystemClock;
+import android.support.v4.app.NotificationCompat;
 
 import com.artemzin.android.wail.R;
 import com.artemzin.android.wail.storage.WAILSettings;
@@ -16,10 +20,16 @@ import com.artemzin.android.wail.util.ThreadUtil;
  */
 public class SoundNotificationsManager {
 
+    private static final Uri ASSET_SOUND_MARKED_SCROBBLED_URI =
+            Uri.parse("file:///android_asset/track_marked_as_scrobbled");
+    private static final Uri ASSET_SOUND_SKIPPED_URI =
+            Uri.parse("file:///android_asset/track_skipped");
+
     private Context context;
     private volatile long lastTrackSkippedPlayTime;
 
     private static volatile SoundNotificationsManager instance;
+    private static int sNextId;
 
     private SoundNotificationsManager(Context context) {
         this.context = context.getApplicationContext();
@@ -52,53 +62,7 @@ public class SoundNotificationsManager {
 
         lastTrackSkippedPlayTime = SystemClock.elapsedRealtime();
 
-        AsyncTaskExecutor.executeConcurrently(new AsyncTask<Object, Object, Object>() {
-            volatile MediaPlayer mediaPlayer;
-
-            @Override
-            protected Object doInBackground(Object... params) {
-                final long startTime = SystemClock.elapsedRealtime();
-
-                try {
-                    mediaPlayer = MediaPlayer.create(context, R.raw.track_skipped);
-                } catch (Exception e) {
-                    Loggi.e("SoundNotificationsManager.playTrackMarkedAsScrobbledSound() exception: " + e);
-                }
-
-                ThreadUtil.sleepIfRequired(startTime, 250);
-
-                return null;
-            }
-
-            @Override
-            protected void onPostExecute(Object o) {
-                super.onPostExecute(o);
-
-                if (mediaPlayer == null) return;
-
-                try {
-                    mediaPlayer.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-                        @Override
-                        public void onCompletion(MediaPlayer mp) {
-                            tryToReleaseMediaPlayer(mediaPlayer);
-                        }
-                    });
-
-                    mediaPlayer.setOnErrorListener(new MediaPlayer.OnErrorListener() {
-                        @Override
-                        public boolean onError(MediaPlayer mp, int what, int extra) {
-                            tryToReleaseMediaPlayer(mediaPlayer);
-                            return false;
-                        }
-                    });
-
-                    mediaPlayer.setVolume(0.07f, 0.07f);
-                    mediaPlayer.start();
-                } catch (Exception e) {
-                    Loggi.e("SoundNotificationsManager.playTrackSkippedSound() can not play sound: " + e);
-                }
-            }
-        });
+        emitSoundNotification(ASSET_SOUND_SKIPPED_URI);
     }
 
     public void playTrackMarkedAsScrobbledSound() {
@@ -110,63 +74,19 @@ public class SoundNotificationsManager {
             Loggi.w("SoundNotificationsManager.playTrackMarkedAsScrobbledSound() disabled");
             return;
         }
-
-        AsyncTaskExecutor.executeConcurrently(new AsyncTask<Void, Void, Void>() {
-
-            volatile MediaPlayer mediaPlayer;
-
-            @Override
-            protected Void doInBackground(Void... params) {
-                final long startTime = SystemClock.elapsedRealtime();
-
-                try {
-                    mediaPlayer = MediaPlayer.create(context, R.raw.track_marked_as_scrobbled);
-                } catch (Exception e) {
-                    Loggi.e("SoundNotificationsManager.playTrackMarkedAsScrobbledSound() exception: " + e);
-                }
-
-                ThreadUtil.sleepIfRequired(startTime, 350);
-
-                return null;
-            }
-
-            @Override
-            protected void onPostExecute(Void aVoid) {
-                super.onPostExecute(aVoid);
-
-                if (mediaPlayer == null) return;
-
-                try {
-                    mediaPlayer.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
-                        @Override
-                        public void onCompletion(MediaPlayer mp) {
-                            tryToReleaseMediaPlayer(mediaPlayer);
-                        }
-                    });
-
-                    mediaPlayer.setOnErrorListener(new MediaPlayer.OnErrorListener() {
-                        @Override
-                        public boolean onError(MediaPlayer mp, int what, int extra) {
-                            tryToReleaseMediaPlayer(mediaPlayer);
-                            return false;
-                        }
-                    });
-
-                    mediaPlayer.setVolume(0.18f, 0.18f);
-                    mediaPlayer.start();
-                } catch (Exception e) {
-                    Loggi.e("SoundNotificationsManager.playTrackMarkedAsScrobbledSound() can not play sound: " + e);
-                }
-            }
-        });
+        emitSoundNotification(ASSET_SOUND_MARKED_SCROBBLED_URI);
     }
 
-    private static void tryToReleaseMediaPlayer(MediaPlayer mediaPlayer) {
-        try {
-            mediaPlayer.reset();
-            mediaPlayer.release();
-        } catch (Exception e) {
-            Loggi.w("SoundNotificationsManager can not release media player");
-        }
+    private void emitSoundNotification(Uri soundUri) {
+        Notification notification = new NotificationCompat.Builder(context)
+                .setSound(soundUri)
+                .build();
+        NotificationManager notificationManager =
+                (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        notificationManager.notify(getNextId(), notification);
+    }
+
+    private static synchronized int getNextId() {
+        return sNextId++;
     }
 }

--- a/wail-app/src/main/java/com/artemzin/android/wail/ui/fragment/settings/SettingsSoundNotificationsFragment.java
+++ b/wail-app/src/main/java/com/artemzin/android/wail/ui/fragment/settings/SettingsSoundNotificationsFragment.java
@@ -25,8 +25,10 @@ import butterknife.OnClick;
  * @author Artem Zinnatullin [artem.zinnatullin@gmail.com]
  */
 public class SettingsSoundNotificationsFragment extends BaseFragment {
-
     private final String GA_EVENT_SETTINGS_SOUND_NOTIFICATIONS = "SettingsSoundNotifications";
+
+    /** Delay in ms to play the sound after the list item is clicked. */
+    private static final long SOUND_DELAY = 100;
 
     @InjectView(R.id.settings_sound_notifications_track_marked_as_scrobbled_switch)
     public SwitchCompat trackMarkedAsScrobbledSoundSwitch;
@@ -91,7 +93,9 @@ public class SettingsSoundNotificationsFragment extends BaseFragment {
                 1L).build());
 
         try {
-            SoundNotificationsManager.getInstance(activity).playTrackMarkedAsScrobbledSound(true);
+            // Delay playing the sound so that it doesn't conflict with the "tap" sound effect.
+            final SoundNotificationsManager soundNotificationManager = SoundNotificationsManager.getInstance(activity);
+            soundNotificationManager.playTrackMarkedAsScrobbledSound(true, SOUND_DELAY);
         } catch (Exception e) {
             Loggi.e("SettingsSoundNotificationsFragment.tryToPlayTrackMarkedAsScrobbledSound() exception: " + e);
             Toast.makeText(activity, R.string.settings_sound_notifications_toast_can_not_play_sound, Toast.LENGTH_LONG).show();
@@ -107,7 +111,7 @@ public class SettingsSoundNotificationsFragment extends BaseFragment {
                 1L).build());
 
         try {
-            SoundNotificationsManager.getInstance(activity).playTrackSkippedSound(true);
+            SoundNotificationsManager.getInstance(activity).playTrackSkippedSound(true, SOUND_DELAY);
         } catch (Exception e) {
             Loggi.e("SettingsSoundNotificationsFragment.tryToPlayTrackSkippedSound() exception: " + e);
             Toast.makeText(activity, R.string.settings_sound_notifications_toast_can_not_play_sound, Toast.LENGTH_LONG).show();


### PR DESCRIPTION
Replace `MediaPlayer` by `RingtoneManager` to play sound notifications.
Tested on my Nexus 5 / Lollipop, the notifications doesn't interrupt the media playback.
Fix issue #184 
