### PR TITLE
App recognition for music players who identify as com.android.music

### DIFF
--- a/wail-app/src/main/java/com/artemzin/android/wail/receiver/music/AndroidMusicReceiver.java
+++ b/wail-app/src/main/java/com/artemzin/android/wail/receiver/music/AndroidMusicReceiver.java
@@ -14,6 +14,9 @@ public class AndroidMusicReceiver extends CommonMusicAppReceiver {
         if (handleTrackIntent != null && originalIntent.hasExtra("com.maxmpz.audioplayer.source")) {
             handleTrackIntent.putExtra(EXTRA_PLAYER_PACKAGE_NAME, "com.maxmpz.audioplayer");
         }
+        if (handleTrackIntent != null && originalIntent.hasExtra("scrobbling_source")) {
+            handleTrackIntent.putExtra(EXTRA_PLAYER_PACKAGE_NAME, originalIntent.getStringExtra("scrobbling_source"));
+        }
 
         return handleTrackIntent;
     }


### PR DESCRIPTION
- As in [Issue #207](https://github.com/artem-zinnatullin/android-wail-app/issues/207) check for specific Intent-Extra when receiving MetaData from generic audio player "com.android.music.XXX"
